### PR TITLE
bundlerのバージョン

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.3-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.22.1)
     parser (3.1.1.0)
@@ -296,6 +298,7 @@ GEM
 PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   annotate


### PR DESCRIPTION
- herokuへデプロイする際に発生したエラーを解決する
- おそらくローカルとherokuのbundlerのバージョンの差異により発生した